### PR TITLE
IHttpProviderDefaults should have a cache property

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1414,6 +1414,7 @@ declare module angular {
     * https://docs.angularjs.org/api/ng/service/$http#defaults
     */
     interface IHttpProviderDefaults {
+    	cache?: true;
         xsrfCookieName?: string;
         xsrfHeaderName?: string;
         withCredentials?: boolean;


### PR DESCRIPTION
The defaults of angular's $httpProvider should have a cache property. 

As per docs: https://docs.angularjs.org/api/ng/provider/$httpProvider#defaults